### PR TITLE
Add support for Sonarqube 5.6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Configure Jest in your `package.json` to use `jest-sonar-reporter` as a custom r
 ```
 
 Configure Sonar to import the test results. Add the `sonar.testExecutionReportPaths` property to your
-`sonar-project.properties` file. 
+`sonar-project.properties` file.
 
-```properites
+```properties
 sonar.testExecutionReportPaths=test-report.xml
 ```
 
@@ -73,6 +73,27 @@ You can customize the following options:
 ```
 
 > Important: Don't forget to update `sonar.testExecutionReportPaths` when you use a custom path and file name.
+
+## Support for Sonarqube 5.6.x
+
+Sonarqube 5.6.x does not support [Generic Test Data](https://docs.sonarqube.org/display/SONAR/Generic+Test+Data) however it has a [Generic Test Coverage plugin](https://docs.sonarqube.org/display/PLUG/Generic+Test+Coverage) which offers similar functionality.
+
+If you have the plugin installed on Sonarqube, you can configure this reporter to produce files in supported format.
+
+```json
+{
+  "jestSonar": {
+    "sonar56x": true
+  }
+}
+```
+
+Configure Sonar to import the test results. Add the `sonar.genericcoverage.unitTestReportPaths` property to your
+`sonar-project.properties` file.
+
+```properties
+sonar.genericcoverage.unitTestReportPaths=test-report.xml
+```
 
 ## Usage
 

--- a/lib/__tests__/__snapshots__/testExecutions.spec.js.snap
+++ b/lib/__tests__/__snapshots__/testExecutions.spec.js.snap
@@ -22,4 +22,6 @@ exports[`testExecutions full report 1`] = `
 </testExecutions>"
 `;
 
-exports[`testExecutions root: <testExecutions version="1"> 1`] = `"<testExecutions version=\\"1\\"></testExecutions>"`;
+exports[`testExecutions root: <testExecutions version="1"> when not formatted for sonar 5.6.x 1`] = `"<testExecutions version=\\"1\\"></testExecutions>"`;
+
+exports[`testExecutions root: <unitTest version="1"> when formatted for sonar 5.6.x 1`] = `"<unitTest version=\\"1\\"></unitTest>"`;

--- a/lib/__tests__/testExecutions.spec.js
+++ b/lib/__tests__/testExecutions.spec.js
@@ -4,10 +4,18 @@ const xml = require('xml')
 const testExecutions = require('../testExecutions')
 
 describe('testExecutions', () => {
-  test('root: <testExecutions version="1">', () => {
+  test('root: <testExecutions version="1"> when not formatted for sonar 5.6.x', () => {
     const mock = {testResults: []}
 
-    const actualReport = xml(testExecutions(mock))
+    const actualReport = xml(testExecutions(mock, false))
+
+    expect(actualReport).toMatchSnapshot()
+  })
+
+  test('root: <unitTest version="1"> when formatted for sonar 5.6.x', () => {
+    const mock = {testResults: []}
+
+    const actualReport = xml(testExecutions(mock, true))
 
     expect(actualReport).toMatchSnapshot()
   })

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -12,13 +12,14 @@ const root = process.cwd()
 const defaultConfig = {
   indent: 2,
   reportPath: process.env.TEST_REPORT_PATH || root,
-  reportFile: 'test-report.xml'
+  reportFile: 'test-report.xml',
+  sonar56x : false
 }
 const packageData = getPackageData(root)
 const config = Object.assign({}, defaultConfig, getConfig(packageData))
 
 module.exports = (results) => {
-  const report = xml(testExecutions(results), {declaration: true, indent: xmlIndent(config.indent)})
+  const report = xml(testExecutions(results, config.sonar56x), {declaration: true, indent: xmlIndent(config.indent)})
 
   if (!fs.existsSync(config.reportPath)) {
     fs.mkdirSync(config.reportPath)

--- a/lib/testExecutions.js
+++ b/lib/testExecutions.js
@@ -1,10 +1,12 @@
-'use strict'
+"use strict";
 
-const file = require('./file')
+const file = require("./file");
 
-module.exports = function testExecutions(data) {
-  const aTestExecution = [{_attr: {version: '1'}}]
-  const testResults = data.testResults.map(file)
+module.exports = function testExecutions(data, formatForSonar56 = false) {
+  const aTestExecution = [{ _attr: { version: "1" } }];
+  const testResults = data.testResults.map(file);
 
-  return {testExecutions: aTestExecution.concat(testResults)}
-}
+  return formatForSonar56
+    ? { unitTest: aTestExecution.concat(testResults) }
+    : { testExecutions: aTestExecution.concat(testResults) };
+};

--- a/lib/testExecutions.js
+++ b/lib/testExecutions.js
@@ -1,10 +1,10 @@
-"use strict";
+'use strict'
 
-const file = require("./file");
+const file = require('./file')
 
 module.exports = function testExecutions(data, formatForSonar56 = false) {
-  const aTestExecution = [{ _attr: { version: "1" } }];
-  const testResults = data.testResults.map(file);
+  const aTestExecution = [{_attr: {version: '1'}}]
+  const testResults = data.testResults.map(file)
 
   return formatForSonar56
     ? { unitTest: aTestExecution.concat(testResults) }


### PR DESCRIPTION
Thanks for the awesome plugin!

This PR introduces support for generating generic reports in format compatible with Sonarqube 5.6.x which is the current LTS release. 

I have tried to find the balance between minimizing the changes and keeping it open for modification for latest Sonar changes. 

Sonarqube 5.6.x is "off" by default and this PR should not be breaking any existing functionality.

Happy to receive any feedback/criticism :-)
