### PR TITLE
add config option to support relative paths for file element in report

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,18 @@ Create a `jestSonar` entry like this:
 ```
 
 You can customize the following options:
-- `reportPath` This will specify the path to put the report in.
-- `reportFile` This will specify the file name of the report.
-- `indent` This will specify the indentation to format the report.
+- `reportPath` (default: `root`, type: `string`) - This will specify the path to put the report in.
+- `reportFile` (default: `'test-report.xml'`, type: `string`) - This will specify the file name of the report.
+- `indent` (default: `2`, type: `number`) - This will specify the indentation to format the report.
+- `useRelativePath` (default: `false`, type: `boolean`) - This will create relative path for file element in report.
 
 ```json
 {
   "jestSonar": {
     "reportPath": "reports",
     "reportFile": "test-reporter.xml",
-    "indent": 4
+    "indent": 4,
+    "useRelativePath": false
   }
 }
 ```
@@ -109,12 +111,12 @@ For example: Overwrite the path were the report will be stored.
     }
   }
 }
-``` 
+```
 
 Use the `NODE_ENV` variable to activate the environment specific configuration.
 ```shell
 NODE_ENV=test npm run test
-``` 
+```
 
 ## Usage
 

--- a/lib/__tests__/__snapshots__/getDefaultConfig.spec.js.snap
+++ b/lib/__tests__/__snapshots__/getDefaultConfig.spec.js.snap
@@ -6,5 +6,6 @@ Object {
   "reportFile": "test-report.xml",
   "reportPath": "/",
   "sonar56x": false,
+  "useRelativePath": false,
 }
 `;

--- a/lib/getDefaultConfig.js
+++ b/lib/getDefaultConfig.js
@@ -4,5 +4,6 @@ module.exports = root => ({
   indent: 2,
   reportPath: root,
   reportFile: 'test-report.xml',
-  sonar56x: false
+  sonar56x: false,
+  useRelativePath: false
 })

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -14,7 +14,7 @@ const packageData = getPackageData(root)
 const config = Object.assign({}, getDefaultConfig(root), getConfig(packageData, process.env.NODE_ENV))
 
 module.exports = (results) => {
-  const report = xml(testExecutions(results, config.sonar56x), {declaration: true, indent: xmlIndent(config.indent)})
+  const report = xml(testExecutions(results, config), {declaration: true, indent: xmlIndent(config.indent)})
 
   if (!fs.existsSync(config.reportPath)) {
     fs.mkdirSync(config.reportPath)

--- a/lib/xml/__tests__/__snapshots__/file.spec.js.snap
+++ b/lib/xml/__tests__/__snapshots__/file.spec.js.snap
@@ -2,6 +2,8 @@
 
 exports[`file <file path=""></file> 1`] = `"<file path=\\"test/FooTest.js\\"></file>"`;
 
+exports[`file path value is relative 1`] = `"<file path=\\"test/RelativePathTest.js\\"></file>"`;
+
 exports[`file testCase tag 1`] = `
 "<file path=\\"test/FooTest.js\\">
     <testCase name=\\"lorem ipsum\\" duration=\\"0\\"/>

--- a/lib/xml/__tests__/file.spec.js
+++ b/lib/xml/__tests__/file.spec.js
@@ -2,6 +2,7 @@
 
 const xml = require('xml')
 const file = require('../file')
+const path = require('path')
 
 describe('file', () => {
   test('<file path=""></file>', () => {
@@ -10,7 +11,18 @@ describe('file', () => {
       testResults: []
     }
 
-    const actualReport = xml(file(mock))
+    const actualReport = xml(file(mock, {useRelativePath: false}))
+
+    expect(actualReport).toMatchSnapshot()
+  })
+
+  test('path value is relative', () => {
+    const mock = {
+      testFilePath: path.join(process.cwd(), 'test', 'RelativePathTest.js'),
+      testResults: []
+    }
+
+    const actualReport = xml(file(mock, {useRelativePath: true}))
 
     expect(actualReport).toMatchSnapshot()
   })
@@ -24,7 +36,7 @@ describe('file', () => {
       ]
     }
 
-    const actualReport = xml(file(mock), true)
+    const actualReport = xml(file(mock, {useRelativePath: false}), true)
 
     expect(actualReport).toMatchSnapshot()
   })

--- a/lib/xml/__tests__/testExecutions.spec.js
+++ b/lib/xml/__tests__/testExecutions.spec.js
@@ -7,7 +7,7 @@ describe('testExecutions', () => {
   test('root: <testExecutions version="1"> when not formatted for sonar 5.6.x', () => {
     const mock = {testResults: []}
 
-    const actualReport = xml(testExecutions(mock, false))
+    const actualReport = xml(testExecutions(mock, {sonar56x: false}))
 
     expect(actualReport).toMatchSnapshot()
   })
@@ -15,7 +15,7 @@ describe('testExecutions', () => {
   test('root: <unitTest version="1"> when formatted for sonar 5.6.x', () => {
     const mock = {testResults: []}
 
-    const actualReport = xml(testExecutions(mock, true))
+    const actualReport = xml(testExecutions(mock, {sonar56x: true}))
 
     expect(actualReport).toMatchSnapshot()
   })
@@ -34,7 +34,7 @@ describe('testExecutions', () => {
       ]
     }
 
-    const actualReport = xml(testExecutions(mock), true)
+    const actualReport = xml(testExecutions(mock, {useRelativePath: false}), true)
 
     expect(actualReport).toMatchSnapshot()
   })
@@ -65,7 +65,7 @@ describe('testExecutions', () => {
       ]
     }
 
-    const actualReport = xml(testExecutions(mock), true)
+    const actualReport = xml(testExecutions(mock, {useRelativePath: false}), true)
 
     expect(actualReport).toMatchSnapshot()
   })

--- a/lib/xml/file.js
+++ b/lib/xml/file.js
@@ -1,9 +1,11 @@
 'use strict'
 
 const testCase = require('./testCase')
+const path = require('path')
 
-module.exports = function file(testResult) {
-  const aFile = [{_attr: {path: testResult.testFilePath}}]
+module.exports = function file(testResult, config) {
+  const testFilePath = config.useRelativePath ? path.relative(process.cwd(), testResult.testFilePath) : testResult.testFilePath
+  const aFile = [{_attr: {path: testFilePath}}]
   const testCases = testResult.testResults.map(testCase)
 
   return {file: aFile.concat(testCases)}

--- a/lib/xml/testExecutions.js
+++ b/lib/xml/testExecutions.js
@@ -2,11 +2,13 @@
 
 const file = require('./file')
 
-module.exports = function testExecutions(data, formatForSonar56) {
+module.exports = function testExecutions(data, config) {
   const aTestExecution = [{_attr: {version: '1'}}]
-  const testResults = data.testResults.map(file)
+  const testResults = data.testResults.map(function(testResult) {
+    return file(testResult, config)
+  })
 
-  return formatForSonar56
+  return config.sonar56x
     ? { unitTest: aTestExecution.concat(testResults) }
     : { testExecutions: aTestExecution.concat(testResults) };
 };


### PR DESCRIPTION
Fixes #
It adds possibility to chose between absolute and relative path in report for file element

Changes proposed in this pull request:
* extend configuration options
* update test coverage
* update readme file

